### PR TITLE
simulate problem

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -32,19 +32,18 @@ var summaries = new[]
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
 
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast = Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
+app.MapGet("/definitely-no-security-flaw", (HttpContext ctx) =>
+    {
+        // Intentionally vulnerable code for CodeQL testing (command injection).
+        var userinput = ctx.Request.Query["userinput"].ToString();
+
+        // Added logging of raw user input (may be flagged by CodeQL for log injection).
+        ctx.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("TestLogger")
+            .LogInformation("Raw user input: " + userinput);
+        return Results.Ok("Logged");
+    })
+    .WithName("definitely-no-security-flaw");
 
 app.Run();
 


### PR DESCRIPTION
This pull request modifies the backend endpoint in `Program.cs` to intentionally introduce vulnerabilities for CodeQL testing. The main change is the replacement of the `/weatherforecast` route with `/definitely-no-security-flaw`, which processes and logs raw user input in a way that can be flagged by security analysis tools.

Intentional vulnerability introduction for CodeQL testing:

* Replaced the `/weatherforecast` endpoint with `/definitely-no-security-flaw`, which accepts a `userinput` query parameter and logs the raw user input, potentially exposing the application to log injection and command injection vulnerabilities.
* Changed the endpoint name from `"GetWeatherForecast"` to `"definitely-no-security-flaw"` to reflect the purpose of the route.